### PR TITLE
add logic to find and print title, pre and p element

### DIFF
--- a/scripts/parse.js
+++ b/scripts/parse.js
@@ -11,7 +11,10 @@ for (let file of Deno.args) {
   let tokens = scan(html)
   let root = tokens.shift()
   let tree = parse(root,tokens)
-  console.log(file, JSON.stringify(tree,null,2))
+  findall(/<title>/, tree, print)
+  findall(/<div id="c1">/, tree, c1 => {
+    findall(/<pre>|<p>/, c1, print)
+  })
 }
 
 function scan(html) {
@@ -37,4 +40,23 @@ function parse(tag, tokens) {
     } 
   }
   return node
+}
+
+function findall(pat, tree, more) {
+  if (pat.exec(tree.tag)) {
+    more(tree)
+  } else {
+    (tree.text||[]).find(each => findall(pat, each, more))
+  }
+}
+
+function flatten(node) {
+  if (typeof node === 'string') return node
+  return (node.text||[]).map(n => flatten(n)).join('')
+}
+
+function print(node) {
+  console.log(node.tag)
+  console.log(flatten(node))
+  console.log()
 }


### PR DESCRIPTION
This completes the parsing of prog21 html files. We search for and print nodes such that nodes are found and flattened to plain text in the order that we would want to read them.

Here is test output for the first file.

```
<title>
A Deeper Look at Tail Recursion in Erlang

<p>
The standard "why tail recursion is good" paragraph talks of reducing stack usage and subroutine calls turning into jumps.  An Erlang process must be tail recursive or else the stack will endlessly grow.  But there's more to how this works behind the scenes, and it directly affects how much code is generated by similar looking tail recursive function calls.

<p>
A long history of looking at disassemblies of C code has made me cringe when I see function calls containing many parameters.  Yet it's common to see ferocious functions in Erlang, like this example from erl_parse (to be fair, it's code generated by yecc):

<pre>
yeccpars2(29, __Cat, __Ss, __Stack, __T, __Ts, __Tzr) -&gt;
   yeccpars2(yeccgoto(expr_700, hd(__Ss)),
      __Cat, __Ss, __Stack, __T, __Ts, __Tzr);

<p>
It's tail recursive, yes, but seven parameters?  Surely this turns into a lot of pushing and popping behind the scenes, even if stack usage is constant.  The good news is that, no, it doesn't.  It's more verbose at the language level than what's really going on.

<p>
There's a simple rule about tail recursive calls in Erlang:  If a parameter is passed to another function, unchanged, in exactly the same position it was passed in, then no virtual machine instructions are generated.  Here's an example:

<pre>
loop(Total, X, Size, Flip) -&gt;
   loop(Total, X - 1, Size, Flip).

<p>
Let's number the parameters from left to right, so Total is 1, X is 2, and so on.  Total enters the function in parameter position 1 and exits, unchanged, in position 1 of the tail call.  The value just rides along in a parameter register.  Ditto for Size in position 3 and Flip in position 4.  In fact, the only change at all is X, so the virtual machine instructions for this function look more or less like:

<pre>
parameter[2]--
goto loop

<p>
Perhaps less intuitively, the same rule applies if the number of parameters increases in the tail call.  This idiom is common in functions with accumulators:

<pre>
count_pairs(List, Limit) -&gt; count_pairs(List, Limit, 0).

<p>
The first two parameters are passed through unchanged.  A third parameter--zero--is tacked onto the end of the parameter list, the only one of the three that involves any virtual machine instructions. 

<p>
In fact, just about the worst thing you can do to violate the "keep parameters in the same positions" rule is to insert a new parameter before the others, or to randomly shuffle parameters.  This code results in a whole bunch of "move parameter" instructions:

<pre>
super_deluxe(A, B, C, D, E, F) -&gt;
   super_deluxe(F, E, D, C, B, A).

<p>
while this code turns into a single jump:

<pre>
super_deluxe(A, B, C, D, E ,F) -&gt;
   super_deluxe(A, B, C, D, E, F).

<p>
These implementation techniques, used in the Erlang BEAM virtual machine, were part of the Warren Abstract Machine developed for Prolog.

```